### PR TITLE
Refactor/hexagonal v3

### DIFF
--- a/acla_ai_service/.importlinter
+++ b/acla_ai_service/.importlinter
@@ -1,0 +1,168 @@
+[importlinter]
+root_package = app
+
+# Hexagonal layering: imports flow downward only.
+#
+#   api  ──►  pipelines  ──►  agents  ──►  ml/llm/voice/integrations  ──►  storage
+#                                              │
+#                                              ▼
+#                          domain / features / skills / infra  (pure leaves)
+#
+# Contracts target the boundaries that REGRESSION would damage. Same-band
+# imports (e.g. one pipeline calling another) are allowed deliberately.
+# See acla-ai-service-architecture.drawio Page 4 for the source-of-truth diagram.
+
+# ─── Leaves: must not depend on anything else in the app ──────────────────────
+
+[importlinter:contract:domain-is-leaf]
+name = app/domain is a leaf (no upward dependencies)
+type = forbidden
+source_modules =
+    app.domain
+forbidden_modules =
+    app.agents
+    app.api
+    app.integrations
+    app.llm
+    app.main
+    app.ml
+    app.pipelines
+    app.storage
+    app.voice
+    app.features
+
+[importlinter:contract:features-is-leaf]
+name = app/features is a leaf (stateless math, no upward dependencies)
+type = forbidden
+source_modules =
+    app.features
+forbidden_modules =
+    app.agents
+    app.api
+    app.integrations
+    app.llm
+    app.main
+    app.ml
+    app.pipelines
+    app.storage
+    app.voice
+
+[importlinter:contract:skills-may-only-touch-domain]
+name = app/skills only reaches into app.domain (for label lookups)
+type = forbidden
+source_modules =
+    app.skills
+forbidden_modules =
+    app.agents
+    app.api
+    app.integrations
+    app.llm
+    app.main
+    app.ml
+    app.pipelines
+    app.storage
+    app.voice
+    app.features
+
+[importlinter:contract:infra-is-leaf]
+name = app/infra (config + observability) imports nothing from app
+type = forbidden
+source_modules =
+    app.infra
+forbidden_modules =
+    app.agents
+    app.api
+    app.domain
+    app.features
+    app.integrations
+    app.llm
+    app.main
+    app.ml
+    app.pipelines
+    app.skills
+    app.storage
+    app.voice
+
+# ─── Storage: bottom of the stack, no upward edges ────────────────────────────
+
+[importlinter:contract:storage-no-upward]
+name = app/storage does not import from any band above
+type = forbidden
+source_modules =
+    app.storage
+forbidden_modules =
+    app.agents
+    app.api
+    app.integrations
+    app.llm
+    app.main
+    app.ml
+    app.pipelines
+    app.voice
+
+# ─── Outbound adapters: don't reach into orchestration or API ─────────────────
+
+[importlinter:contract:llm-no-pipeline-or-api]
+name = app/llm never imports pipelines, agents, or api
+type = forbidden
+source_modules =
+    app.llm
+forbidden_modules =
+    app.agents
+    app.api
+    app.main
+    app.pipelines
+
+[importlinter:contract:voice-no-pipeline-or-api]
+name = app/voice never imports pipelines or api (voice is an outbound adapter)
+type = forbidden
+source_modules =
+    app.voice
+forbidden_modules =
+    app.api
+    app.main
+    app.pipelines
+
+[importlinter:contract:integrations-no-pipeline-or-api]
+name = app/integrations never imports pipelines or api
+type = forbidden
+source_modules =
+    app.integrations
+forbidden_modules =
+    app.agents
+    app.api
+    app.main
+    app.pipelines
+
+[importlinter:contract:ml-no-pipeline-or-api]
+name = app/ml never imports pipelines, agents, or api (model code is pure)
+type = forbidden
+source_modules =
+    app.ml
+forbidden_modules =
+    app.agents
+    app.api
+    app.main
+    app.pipelines
+
+# ─── Agent box: domain-free; never reaches into pipelines or api ──────────────
+
+[importlinter:contract:agents-stays-pure]
+name = agent capability box never reaches into pipelines, api, or main
+type = forbidden
+source_modules =
+    app.agents
+forbidden_modules =
+    app.api
+    app.main
+    app.pipelines
+
+# ─── API: thin inbound adapter; never reaches into main/__init__ recursively ──
+
+[importlinter:contract:api-stays-thin]
+name = app/api never imports main (api is reached FROM main, not the reverse)
+type = forbidden
+source_modules =
+    app.api
+forbidden_modules =
+    app.main

--- a/acla_ai_service/app/api/__init__.py
+++ b/acla_ai_service/app/api/__init__.py
@@ -2,11 +2,13 @@
 API routers initialization
 """
 
+from .annotation import router as annotation_router
 from .health import router as health_router
 from .racing_session import router as racing_session_router
 
 
 __all__ = [
-    "health_router", 
+    "annotation_router",
+    "health_router",
     "racing_session_router",
 ]

--- a/acla_ai_service/app/api/annotation.py
+++ b/acla_ai_service/app/api/annotation.py
@@ -1,0 +1,198 @@
+"""Annotation pipeline HTTP endpoint.
+
+`POST /annotation/run` is the inbound boundary for kicking off an
+annotation run from outside the service. It replaces the in-process
+`from app.pipelines.annotation import run_annotation` import that the
+Streamlit researcher UI uses today — Step 13 of the hexagonal refactor.
+
+The endpoint loads the requested DataFrame from the AI service's own
+Zarr telemetry store (the same store the UI uses today), so callers
+only need to send a `(cache_key, session_id)` reference rather than
+serialising several MB of telemetry per request.
+
+Streaming progress callbacks (the `progress_callback`, `vlm_stream_callback`,
+etc. the UI relies on for live VLM token rendering) are NOT yet exposed
+here; they require Server-Sent Events. A follow-up endpoint at
+`/annotation/run/stream` will add that surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.pipelines.annotation import (
+    AnnotationPipelineConfig,
+    AnnotationResult,
+    LapAnnotationResult,
+    run_annotation,
+)
+from app.storage.zarr import get_shared_zarr_store
+
+LOGGER = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/annotation", tags=["annotation"])
+
+
+Flow = Literal["detailed", "lap"]
+Backend = Literal["local", "claude"]
+
+
+class _ConfigBody(BaseModel):
+    """Config knobs forwarded to AnnotationPipelineConfig.
+
+    Mirrors the dataclass fields without their callback machinery — the
+    HTTP entrypoint omits streaming callbacks (deferred to SSE).
+    """
+
+    backend: Backend = "local"
+    max_new_tokens: int = 1500
+    temperature: float = 0.7
+
+    # local VLM (llama-server)
+    gguf_path: Optional[str] = None
+    mmproj_path: Optional[str] = None
+    context_size: int = 32768
+    n_gpu_layers: int = -1
+    hf_repo: str = "Qwen/Qwen2.5-VL-72B-Instruct"
+    quantization_type: str = "Q4_K_M"
+
+    # claude
+    claude_model: str = "claude-sonnet-4-6"
+    claude_use_thinking: bool = False
+
+
+class _AnnotationRunRequest(BaseModel):
+    """Body for `POST /annotation/run`.
+
+    The dataframe is referenced by `(cache_key, session_id)` so the AI
+    service loads it from its own Zarr store — clients don't have to
+    serialise telemetry payloads.
+    """
+
+    flow: Flow
+    cache_key: str = Field(..., description="Zarr cache key (group path) for the dataset")
+    session_id: str = Field(..., description="Chunk / session ID within the cache key")
+    session_label: str = Field("", description="Forwarded to AgentResponse.session_id for audit")
+    config: Optional[_ConfigBody] = None
+
+    # detailed-flow inputs
+    start_index: Optional[int] = None
+    end_index: Optional[int] = None
+    parent_main_labels: Optional[List[str]] = None
+    existing_children: Optional[List[Dict[str, Any]]] = None
+
+    # lap-flow inputs
+    lap_start: Optional[int] = None
+    lap_end: Optional[int] = None
+    section_id: Optional[str] = None
+    section_start: Optional[int] = None
+    section_end: Optional[int] = None
+    circuit_id: Optional[str] = None
+    existing_section_annotations: Optional[List[Dict[str, Any]]] = None
+
+
+def _result_to_dict(result: Any) -> Dict[str, Any]:
+    """AnnotationResult / LapAnnotationResult are dataclasses; convert to dict
+    without forcing callers to learn each one's field layout."""
+    if is_dataclass(result):
+        return asdict(result)
+    if isinstance(result, dict):
+        return result
+    raise TypeError(f"Unsupported annotation result type: {type(result).__name__}")
+
+
+def _load_dataframe(cache_key: str, session_id: str):
+    """Pull the DataFrame for ``(cache_key, session_id)`` from the Zarr store."""
+    store = get_shared_zarr_store()
+    chunk = store.get_chunk(cache_key, session_id)
+    if not chunk:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"No telemetry found for cache_key={cache_key!r} "
+                f"session_id={session_id!r}"
+            ),
+        )
+
+    raw = chunk
+    if isinstance(chunk, dict) and "data" in chunk:
+        raw = chunk["data"]
+    if not isinstance(raw, list):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Telemetry chunk is not a list of records (got {type(raw).__name__})",
+        )
+
+    # Deferred to avoid importing pandas at module load.
+    import pandas as pd
+    return pd.DataFrame(raw)
+
+
+@router.post("/run")
+async def annotation_run(req: _AnnotationRunRequest) -> Dict[str, Any]:
+    """Run one annotation pass.
+
+    Replaces the in-process `run_annotation(...)` call the Streamlit UI
+    makes today. Streaming progress is NOT surfaced here — clients that
+    need per-step VLM tokens should wait for `/annotation/run/stream`.
+    """
+    df = _load_dataframe(req.cache_key, req.session_id)
+
+    config_body = req.config or _ConfigBody()
+    config = AnnotationPipelineConfig(
+        backend=config_body.backend,
+        max_new_tokens=config_body.max_new_tokens,
+        temperature=config_body.temperature,
+        gguf_path=config_body.gguf_path,
+        mmproj_path=config_body.mmproj_path,
+        context_size=config_body.context_size,
+        n_gpu_layers=config_body.n_gpu_layers,
+        hf_repo=config_body.hf_repo,
+        quantization_type=config_body.quantization_type,
+        claude_model=config_body.claude_model,
+        claude_use_thinking=config_body.claude_use_thinking,
+    )
+
+    try:
+        result = run_annotation(
+            flow=req.flow,
+            df=df,
+            config=config,
+            session_id=req.session_label,
+            # detailed-flow inputs (run_annotation validates which set is required)
+            start_index=req.start_index,
+            end_index=req.end_index,
+            parent_main_labels=req.parent_main_labels,
+            existing_children=req.existing_children,
+            # lap-flow inputs
+            lap_start=req.lap_start,
+            lap_end=req.lap_end,
+            section_id=req.section_id,
+            section_start=req.section_start,
+            section_end=req.section_end,
+            circuit_id=req.circuit_id,
+            existing_section_annotations=req.existing_section_annotations,
+        )
+    except ValueError as exc:
+        # run_annotation raises ValueError for missing required kwargs.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        LOGGER.exception("Annotation run failed (flow=%s)", req.flow)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Annotation failed: {type(exc).__name__}: {exc}",
+        ) from exc
+
+    return {
+        "flow": req.flow,
+        "backend": config.backend,
+        "result": _result_to_dict(result),
+    }
+
+
+__all__ = ["router"]

--- a/acla_ai_service/app/api/voice.py
+++ b/acla_ai_service/app/api/voice.py
@@ -179,13 +179,20 @@ async def voice_stream(
         user_id=user_id,
     )
 
+    # Construct the tool executor here, in the inbound-adapter band, so
+    # app/voice/ never imports from app/pipelines/ (see .importlinter
+    # contract voice-no-pipeline-or-api).
+    from app.pipelines.chat import AIService
+    ai_service = AIService()
+    tool_executor = ai_service._execute_function
+
     LOGGER.info(
         "Voice WS connected (track=%s car=%s user=%s)",
         track_name, car_name, user_id,
     )
 
     try:
-        await run_voice_session(websocket, config)
+        await run_voice_session(websocket, config, tool_executor)
     except WebSocketDisconnect:
         LOGGER.info("Voice WS client disconnected (user=%s)", user_id)
     except Exception:

--- a/acla_ai_service/app/main.py
+++ b/acla_ai_service/app/main.py
@@ -11,6 +11,7 @@ from app.infra.config import settings
 from app.integrations.backend.client import backend_service
 from app.llm.health import check_llama_server
 from app.api import (
+    annotation_router,
     health_router,
     racing_session_router,
 )
@@ -83,6 +84,7 @@ app.include_router(health_router)
 app.include_router(query_router)  # Main query endpoint
 app.include_router(racing_session_router)
 app.include_router(voice_router)  # Phase 2 — neural TTS (Kokoro)
+app.include_router(annotation_router)  # Step 13 — replaces Streamlit's in-process import
 
 if __name__ == "__main__":
     import uvicorn

--- a/acla_ai_service/app/pipelines/training/full_dataset.py
+++ b/acla_ai_service/app/pipelines/training/full_dataset.py
@@ -225,6 +225,7 @@ class Full_dataset_TelemetryMLService:
                     model_subtype="imitation_model_data",
                     service_instance=self._expert_service,
                     deserializer_func=self._expert_service.deserialize_imitation_model,
+                    backend_fetcher=self.backend_service.getCompleteActiveModelData,
                 )
                 chunk_imitation_features = expert_service.extract_expert_state_for_telemetry(
                     [processed_telemetry_dict]
@@ -238,6 +239,7 @@ class Full_dataset_TelemetryMLService:
                 model_subtype="tire_grip_model_data",
                 service_instance=self._tire_grip_service,
                 deserializer_func=self._tire_grip_service.deserialize_tire_grip_model,
+                backend_fetcher=self.backend_service.getCompleteActiveModelData,
             )
             chunk_grip_features = await tire_grip_service.extract_tire_grip_features(
                 [processed_telemetry_dict]

--- a/acla_ai_service/app/storage/cache/__init__.py
+++ b/acla_ai_service/app/storage/cache/__init__.py
@@ -9,7 +9,7 @@ import os
 import threading
 import time
 from collections import OrderedDict
-from typing import Dict, Any, Optional, Tuple, List
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field
 import hashlib
@@ -287,15 +287,22 @@ class ModelCacheService:
         model_subtype: str,
         service_instance: Any,
         deserializer_func: callable,
+        backend_fetcher: Optional[Callable[[str], Any]] = None,
     ) -> Tuple[Any, Dict[str, Any]]:
-        """Fetch model from cache or backend if missing"""
+        """Fetch model from cache; fall back to ``backend_fetcher(model_type)``
+        if missing. The fetcher is injected by the caller (e.g.
+        ``backend_service.getCompleteActiveModelData``) so this storage band
+        stays independent of app.integrations — see .importlinter contract
+        ``storage-no-upward``."""
         cached = self.get(model_type=model_type, model_subtype=model_subtype)
         if cached:
             return cached[0], cached[1]
 
+        if backend_fetcher is None:
+            return service_instance, {}
+
         try:
-            from app.integrations.backend.client import backend_service
-            model_data = await backend_service.getCompleteActiveModelData(modelType=model_type)
+            model_data = await backend_fetcher(model_type)
             if model_data and hasattr(model_data, 'modelData'):
                 deserializer_func(model_data.modelData)
                 metadata = getattr(model_data, 'metrics', {})
@@ -307,7 +314,7 @@ class ModelCacheService:
                 )
                 return service_instance, metadata
         except Exception as e:
-            logger.warning(f"Failed to fetch model {model_type} from backend: {e}")
+            logger.warning(f"Failed to fetch model {model_type} via backend_fetcher: {e}")
 
         return service_instance, {}
     

--- a/acla_ai_service/app/voice/pipecat_pipeline.py
+++ b/acla_ai_service/app/voice/pipecat_pipeline.py
@@ -130,8 +130,11 @@ def _build_tool_schemas():
     return [check_car_limit_schema, track_detail_schema]
 
 
-def _make_tool_handler(ai_service, session_config: "VoiceSessionConfig"):
-    """Build a per-session async handler that delegates to AIService._execute_function.
+def _make_tool_handler(tool_executor, session_config: "VoiceSessionConfig"):
+    """Build a per-session async handler that delegates to ``tool_executor``.
+    The executor is injected by the caller (api/voice.py wires
+    AIService._execute_function into this slot) so app/voice/ stays out
+    of app/pipelines/ — see .importlinter contract voice-no-pipeline-or-api.
 
     Closes over `session_config` so per-session context (track/car) is
     forwarded to the existing tool implementations exactly as the HTTP
@@ -148,7 +151,7 @@ def _make_tool_handler(ai_service, session_config: "VoiceSessionConfig"):
         }
 
         try:
-            result = await ai_service._execute_function(function_name, arguments, context)
+            result = await tool_executor(function_name, arguments, context)
         except Exception as exc:
             LOGGER.exception("Voice tool %s failed", function_name)
             await params.result_callback({"error": str(exc)})
@@ -177,6 +180,7 @@ def _make_tool_handler(ai_service, session_config: "VoiceSessionConfig"):
 async def build_voice_pipeline_task(
     websocket: Any,
     session_config: VoiceSessionConfig,
+    tool_executor: Any,
 ):
     """Build a Pipecat PipelineTask bound to the given WebSocket.
 
@@ -200,7 +204,6 @@ async def build_voice_pipeline_task(
         FastAPIWebsocketTransport,
     )
 
-    from app.pipelines.chat import AIService
     from app.voice.pipecat_kokoro import build_kokoro_processor
 
     LOGGER.info(
@@ -258,14 +261,14 @@ async def build_voice_pipeline_task(
     )
 
     # --- Tool calling (Phase 3b) ---
-    # Build schemas + register handlers that delegate to the existing
-    # AIService._execute_function. Voice and text paths share the same tool
-    # implementations, so behavior stays consistent.
-    ai_service = AIService()
+    # Build schemas + register handlers that delegate to the caller-provided
+    # `tool_executor` (typically AIService._execute_function, bound by
+    # api/voice.py). Voice and text paths share the same tool implementations,
+    # so behaviour stays consistent.
     tool_schemas = _build_tool_schemas()
     tools = ToolsSchema(standard_tools=tool_schemas)
 
-    tool_handler = _make_tool_handler(ai_service, session_config)
+    tool_handler = _make_tool_handler(tool_executor, session_config)
     for schema in tool_schemas:
         llm.register_function(schema.name, tool_handler)
 
@@ -306,16 +309,21 @@ async def build_voice_pipeline_task(
     return task
 
 
-async def run_voice_session(websocket: Any, session_config: VoiceSessionConfig) -> None:
+async def run_voice_session(
+    websocket: Any,
+    session_config: VoiceSessionConfig,
+    tool_executor: Any,
+) -> None:
     """Bind a Pipecat pipeline to `websocket` and run it to completion.
 
     Returns when the WS closes or the pipeline exits. Caller is responsible
-    for any auth/lifecycle concerns around `websocket`.
+    for any auth/lifecycle concerns around `websocket` and for supplying a
+    ``tool_executor`` (typically AIService._execute_function).
     """
     # Deferred import.
     from pipecat.pipeline.runner import PipelineRunner
 
-    task = await build_voice_pipeline_task(websocket, session_config)
+    task = await build_voice_pipeline_task(websocket, session_config, tool_executor)
     runner = PipelineRunner()
     try:
         await runner.run(task)

--- a/acla_ai_service/tests/test_agent_framework.py
+++ b/acla_ai_service/tests/test_agent_framework.py
@@ -153,9 +153,18 @@ def test_budget_total_spawn_limit() -> None:
 # ---------------------------------------------------------------------------
 
 
+# `_parse_zoom_decision` filters zoom requests against an `available_graph_ids`
+# list (added when the planner started selecting per-zoom graph subsets).
+# When a request omits `requested_graphs`, the function defaults to ALL
+# available ones — so passing an empty list does NOT silently keep every
+# range; tests below pass an explicit non-empty list when they care about
+# survivors and an empty list when they expect everything to drop anyway.
+_TEST_GRAPHS = ["graph_a", "graph_b"]
+
+
 def test_parse_zoom_decision_no_zoom() -> None:
     text = '{"zoom": false}'
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert zoom is False
     assert ranges == []
 
@@ -165,11 +174,11 @@ def test_parse_zoom_decision_fenced_json() -> None:
         "Some prose.\n"
         "```json\n"
         '{"zoom": true, "ranges": ['
-        f'{{"start": 100, "end": {100 + MIN_ZOOM_SPAN + 5}, "reason": "x"}}'
+        f'{{"start": 100, "end": {100 + MIN_ZOOM_SPAN + 5}, "question": "x"}}'
         "]}\n"
         "```\n"
     )
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert zoom is True
     assert len(ranges) == 1
     assert ranges[0]["start"] == 100
@@ -179,10 +188,10 @@ def test_parse_zoom_decision_drops_short_span() -> None:
     short = MIN_ZOOM_SPAN - 1
     text = (
         '{"zoom": true, "ranges": [{'
-        f'"start": 10, "end": {10 + short}, "reason": "x"'
+        f'"start": 10, "end": {10 + short}, "question": "x"'
         "}]}"
     )
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert ranges == []
     assert zoom is False    # no valid ranges → effectively no zoom
 
@@ -190,41 +199,43 @@ def test_parse_zoom_decision_drops_short_span() -> None:
 def test_parse_zoom_decision_drops_outside_parent_range() -> None:
     text = (
         '{"zoom": true, "ranges": [{'
-        f'"start": 5000, "end": 5100, "reason": "out of range"'
+        f'"start": 5000, "end": 5100, "question": "out of range"'
         "}]}"
     )
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert ranges == []
     assert zoom is False
 
 
-def test_parse_zoom_decision_caps_count() -> None:
+def test_parse_zoom_decision_keeps_all_valid() -> None:
+    """Three valid ranges all survive — `_parse_zoom_decision` no longer
+    caps; capping is the planner's responsibility now, not the parser's."""
     text = (
         '{"zoom": true, "ranges": ['
-        f'{{"start": 0, "end": {MIN_ZOOM_SPAN}, "reason": "a"}},'
-        f'{{"start": 100, "end": {100 + MIN_ZOOM_SPAN}, "reason": "b"}},'
-        f'{{"start": 200, "end": {200 + MIN_ZOOM_SPAN}, "reason": "c"}}'
+        f'{{"start": 0, "end": {MIN_ZOOM_SPAN}, "question": "a"}},'
+        f'{{"start": 100, "end": {100 + MIN_ZOOM_SPAN}, "question": "b"}},'
+        f'{{"start": 200, "end": {200 + MIN_ZOOM_SPAN}, "question": "c"}}'
         "]}"
     )
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert zoom is True
-    assert len(ranges) == 2     # capped at MAX_ZOOM_STEPS
+    assert len(ranges) == 3
 
 
 def test_parse_zoom_decision_drops_invalid_types() -> None:
     text = (
         '{"zoom": true, "ranges": [{'
-        '"start": "80", "end": 130, "reason": "bad start type"'
+        '"start": "80", "end": 130, "question": "bad start type"'
         "}]}"
     )
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert ranges == []
     assert zoom is False
 
 
 def test_parse_zoom_decision_no_json_returns_no_zoom() -> None:
     text = "Just prose, no JSON object here."
-    zoom, ranges = _parse_zoom_decision(text, 0, 1000)
+    zoom, ranges = _parse_zoom_decision(text, 0, 1000, _TEST_GRAPHS)
     assert zoom is False
     assert ranges == []
 


### PR DESCRIPTION
# Refactor PR #3 — tests, linter contract, annotation HTTP endpoint

Stacks on top of `refactor/hexagonal-v2`. Three small commits that
finalise the architectural work and pay down the remaining debt
from PRs #1–2 — no big sweeping moves, just tightening.

## Commits

| # | What | Files |
|---|---|---|
| 1 | Fix 7 stale `_parse_zoom_decision` tests | 1 |
| 2 | Add `.importlinter` contract + fix 2 layering violations it caught | 5 |
| 3 | `POST /annotation/run` endpoint — Streamlit no longer has to import pipelines in-process | 3 |

## What got fixed

### 1. Stale tests (24 passing now, was 17 pass + 7 fail)

Three independent regressions had drift-broken every zoom test:

1. Missing the `available_graph_ids` parameter — added when the
   planner started filtering which graphs each zoom request could see.
2. Test fixtures used `"reason"` but the function expects `"question"`
   — field was renamed in production, tests were orphaned. With this
   bug, the **fenced_json** + **caps_count** tests would never have
   produced their asserted output.
3. **caps_count** asserted a `MAX_ZOOM_STEPS=2` cap that doesn't exist
   anymore — capping moved out of the parser into the planner.
   Renamed the test to `keeps_all_valid` to document the new
   contract.

### 2. import-linter contract — locks the hexagonal layering

`acla_ai_service/.importlinter` encodes Page 4 of the architecture
diagram. 11 contracts, all kept:

```
app/domain, app/features, app/skills, app/infra → pure leaves
app/storage → no upward edges
app/ml, app/llm, app/voice, app/integrations → outbound only
app/agents → never reaches pipelines/api/main
app/api → never imports main (reached FROM main)
```

Two real architectural violations had to be fixed before the contract
could pass — both are dependency-inversion refactors, not behavioural
changes:

| Violation | Fix |
|---|---|
| `app.storage.cache → app.integrations.backend` (in `get_model_or_fetch`'s fallback path) | Inject a `backend_fetcher: Callable` parameter. Callers in `pipelines/training/full_dataset.py` pass `backend_service.getCompleteActiveModelData` explicitly. Storage stays unaware of integrations. |
| `app.voice.pipecat_pipeline → app.pipelines.chat` (it was instantiating `AIService()` to harvest tool-handler functions) | Invert: `run_voice_session` now takes a `tool_executor` parameter; the WebSocket endpoint at `api/voice.py` constructs AIService and passes `ai_service._execute_function` in. Voice is back to being a pure outbound adapter. |

`import-linter` is installed in the dev container but **not yet
promoted to CI** — that's a follow-up so the contract can stabilise
under live use first.

### 3. `POST /annotation/run` — Streamlit decoupling

Adds the HTTP boundary the diagram promised on Page 1 (the dashed
endpoint). The Streamlit researcher UI currently does `from
app.pipelines.annotation import run_annotation` in the same Python
process — fine for dev but couples the two containers indefinitely.

Now there's a clean replacement:

```http
POST /annotation/run
{
  "flow": "detailed",
  "cache_key": "user_session_abc",
  "session_id": "lap_42",
  "start_index": 100, "end_index": 5000,
  "parent_main_labels": ["EA"],
  "existing_children": [...],
  "config": { "backend": "local", ... }
}
```

Telemetry is referenced by `(cache_key, session_id)` rather than
JSON-serialised — the AI service loads from its own Zarr store via
`app.storage.zarr.get_shared_zarr_store()`. Streaming progress
callbacks (vlm_stream_callback etc.) are NOT yet surfaced; they need
SSE, deferred to a `/annotation/run/stream` follow-up.

Smoke-tested:

- `{}` → 422 with field-by-field list of what's missing
- `{"flow": "bogus", …}` → 422 literal-error pointing at flow
- unknown cache_key → 404 with descriptive detail

## What's still left

- **Page-5 internal ML splits** — `transformer_model.py`,
  `imitate_expert_learning_service.py`, `segment_classifier_service.py`
  are still monoliths inside their new homes. Splitting them is the
  headline work for PR #4.
- **SSE `/annotation/run/stream`** — Streamlit's live VLM token
  display needs progress callbacks; this endpoint delivers them
  over Server-Sent Events. Quick follow-up, but not in this PR.
- **Promote `import-linter` to CI** — once the contract proves stable
  over a couple of weeks of changes, add a workflow that fails the
  build on `lint-imports` violations.

## Validation

- 24/24 pytest tests pass
- `lint-imports` reports 11 contracts kept, 0 broken
- `/health`, `/voice/health`, `/annotation/run` all return 200/422/404
  correctly
- `app.main` imports clean inside the container
- `AIService()` still instantiates end-to-end (the DI refactor didn't
  break the existing wiring)